### PR TITLE
add possibility to give the due date to XML in SpecifiedTradePaymentTerms

### DIFF
--- a/DEMO-rechnung-zugferd.tex
+++ b/DEMO-rechnung-zugferd.tex
@@ -12,6 +12,7 @@
 
 \newkomafont{invoicetotal}{\bfseries}
 
+
 \SetZUGFeRDData{
 	document-type =  commercial-invoice ,
 	id=komavar,
@@ -40,6 +41,7 @@
 	buyer/email = {invoice@example.org},
 	currency=€,
 	payment-terms={Zahlbar innerhalb von 14 Tagen},
+	payment-terms/date={20240118},
 	payment-means / type = 58, % SEPA Übereisung,
 	payment-means / iban = DE68430609671013251700,
 	payment-means / account-holder = Marei Peischl,

--- a/zugferd-invoice.sty
+++ b/zugferd-invoice.sty
@@ -71,7 +71,7 @@
 	
 	\cs_gset_eq:NN \__ptxcd_write_TradeLineItem:nnnnnn  \__zugferd_insert_TradeLineItem:nnnnnn
 	\cs_gset:Nn 	\__ptxcd_PrintInvoiceSummation:nnnnnnnn {
-		\__zugferd_SpecifiedTradePaymentTerms:
+		\__zugferd_SpecifiedTradePaymentTermsWithDueDate:
 		\__zugferd_SpecifiedTradeSettlementHeaderMonetarySummation:nnnnnnnn {##1} {##2} {##3} {##4} {##5} {##6} {##7} {##8}
 	}
 	\cs_gset:Nn \__ptxcd_write_HeaderTradeAgreement: {

--- a/zugferd.dtx
+++ b/zugferd.dtx
@@ -805,6 +805,7 @@
 	currency / € .meta:n = {currency = EUR},
 	% add support for all currencies/make case-insensitive/unknown
 	payment-terms .str_gset:N = \_@@_payment_terms_str,
+	payment-terms/date .str_gset:N = \_@@_payment_terms_date_str,
 	payment-means / type .choices:nn = {10,20,30,42,48,49,57,58,59,97} {\tl_set_eq:NN \l_@@_payment_means_tl \l_keys_choice_tl},
 }
 
@@ -893,6 +894,17 @@
 		</ram:SpecifiedTradePaymentTerms>%
 	}%
 }%
+% SpecifiedTradePaymentTerms with machine readable due date
+\cs_new:Nn \_@@_SpecifiedTradePaymentTermsWithDueDate:nn {%
+	\_@@_write_xml:e {%
+		<ram:SpecifiedTradePaymentTerms>
+			\_@@_xml_indent:<ram:Description>#1</ram:Description>
+			\_@@_xml_indent:<ram:DueDateDateTime>
+			\_@@_xml_indent:\_@@_xml_indent:\_@@_xml_indent:<udt:DateTimeString~format="102">#2</udt:DateTimeString>
+			\_@@_xml_indent:</ram:DueDateDateTime>
+		</ram:SpecifiedTradePaymentTerms>%
+	}%
+}%
 %
 %
 % sums
@@ -919,6 +931,7 @@
 }%
 \endgroup
 \cs_new:Nn \_@@_SpecifiedTradePaymentTerms: {\_@@_SpecifiedTradePaymentTerms:n {\_@@_payment_terms_str}}
+\cs_new:Nn \_@@_SpecifiedTradePaymentTermsWithDueDate: {\_@@_SpecifiedTradePaymentTermsWithDueDate:nn {\_@@_payment_terms_str}{\_@@_payment_terms_date_str}}
 %    \end{macrocode}
 % \begin{function}{\_@@_SpecifiedTradeSettlementPaymentMeans:}
 %    \begin{macrocode}


### PR DESCRIPTION
For the SpecifiedTradePaymentTerms, I want to have the possibility to give the DueDate in a machine readable way as specified in the ZUGFeRD documentation.
To keep things backward compatible, I added a new function for this.
