### PR TITLE
zugferd.dtx: Avoid siunitx deprecation warning

### DIFF
--- a/zugferd.dtx
+++ b/zugferd.dtx
@@ -959,7 +959,7 @@
 		round-mode=places,
 		round-precision=#1,
 		round-pad = false,
-		group-digits=false,
+		group-digits=none,
 		minimum-decimal-digits=#1,
 		output-decimal-marker=.
 	}


### PR DESCRIPTION
This resolves the following warning:

Package siunitx Info: Option "group-digits = false" has been deprecated in
(siunitx)             this release.
(siunitx)
(siunitx)             Use "group-digits = none" as a replacement.