### PR TITLE
Fix spacing after \XMLfile with \xspace

### DIFF
--- a/zugferd.dtx
+++ b/zugferd.dtx
@@ -235,7 +235,7 @@
 
 \usepackage{xspace}
 \newcommand*{\XML}{XML\xspace}
-\newcommand*{\XMLfile}{\XML file}
+\newcommand*{\XMLfile}{\XML file\xspace}
 
 \DeclareRobustCommand{\issue}[1]{%
 	{\DeclareFieldFormat{citeurlpostfix}{\href{##1/issues/#1}{\##1}}\citefield{LaTeX-ZUGFeRD-GitHub}[citeurlpostfix]{url}}%


### PR DESCRIPTION
While reading the documentation, I noticed that the phrase "XML file" would not be separated from the next word by a space.  For instance, in the abstract, the second to last sentence is like this:

So it also creates the XML filefor

where the words "file" and "for" are not separated by a space.  This can be fixed by using the `\xspace` command when defining the `\XMLfile` command as is implemented in this patch.

This patch is submitted in the hope that it is useful. If anything needs updating or changing, please let me know and I'll be more than happy to fix things and resubmit as necessary.