### PR TITLE
fix lazy komavar evaluation and empty BuyerReference; add seller/name=komavar

### DIFF
--- a/.github/workflows/l3build.yaml
+++ b/.github/workflows/l3build.yaml
@@ -24,8 +24,14 @@ jobs:
       # download validate_zugferd.sh to support/ so it's not done multiple times later
       - run: cd support && bash validate_zugferd.sh && cd -
       - run: l3build check
+      - run: l3build unpack
       - run: bash support/validate_zugferd.sh build/doc/DEMO*.pdf
-      - name: Upload build artifats
+      - name: Upload zugferd.sty
+        uses: actions/upload-artifact@v4
+        with:
+          name: zugferd-sty
+          path: build/unpacked/zugferd.sty
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: zugferd-ctan

--- a/DEMO-rechnung-zugferd-Kleinunternehmen.tex
+++ b/DEMO-rechnung-zugferd-Kleinunternehmen.tex
@@ -32,6 +32,11 @@
 \setkomavar{invoice}{2024:1337}
 \setkomavar{date}{{\InsertZUGFeRDData[set-today]{date}\today}}
 \setkomavar{title}{Rechnung}
+% Seller data is read from these KOMA-Script variables at XML-write time.
+% This avoids duplicating data already defined in a letter option file.
+\setkomavar{fromname}{Kleinunternehmer*in X}
+\setkomavar{fromemail}{kontakt@peitex.de}
+\setkomavar{fromphone}{+4900000000}
 
 \SetZUGFeRDData{
 %	document-type =  commercial-invoice, % commented as this setting matches the initial value
@@ -41,15 +46,17 @@
 	subject=komavar,
 	fromaddress=komavar,
 	unit=hour,
-	seller/vatid = {DE123456789},
-%	seller/id=1123,% If no VatID exists a seller/id is required. This might be an ID provided by the buyer
-	seller/name = {Kleinunternehmer*in X},
+%	seller/vatid = {DE123456789},% Kleinunternehmer*innen have no VAT ID; use seller/id instead (BR-CO-26)
+	seller/id=XXXXX,% required if no seller/vatid: use any unique seller identifier (e.g. tax number)
+	seller/name = komavar,% reads \setkomavar{fromname} above
 	seller/postcode = {20253},
 	seller/city ={Hamburg},
 	seller/country = DE,
 	seller/address = {Address 1},
-	seller/contact= {Marei\\+4900000000\\marei@peitex.de},
-	seller/email = {kontakt@peitex.de},
+	seller/contact-name = komavar,% reads \setkomavar{fromname} above
+	seller/contact-phone = komavar,% reads \setkomavar{fromphone} above
+	seller/contact-email = komavar,% reads \setkomavar{fromemail} above
+	seller/email = komavar,% reads \setkomavar{fromemail} above
 	seller/taxid=XXXXX,
 	buyer/reference = {buyer-reference}, %oder Leitweg-ID
 	buyer/name = {Käufer Name},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  l3build:
+    image: texlive/texlive:latest
+    volumes:
+      - .:/workspace
+    working_dir: /workspace
+    command: l3build check

--- a/testfiles/seller-komavar.lvt
+++ b/testfiles/seller-komavar.lvt
@@ -1,0 +1,68 @@
+\input regression-test.tex\relax
+% Use scrartcl so that scrletter's \setkomavar is available
+\documentclass{scrartcl}
+
+% Set KOMA-Script letter variables BEFORE loading zugferd to verify lazy evaluation
+\usepackage{scrletter}
+
+\usepackage[zugferd=false]{zugferd}
+
+% Set komavars after \usepackage to verify that lazy evaluation works
+% regardless of order relative to \SetZUGFeRDData
+\setkomavar{fromname}{peiTeX (Marei Peischl)}
+\setkomavar{fromemail}{kontakt@peitex.de}
+\setkomavar{fromphone}{+4900000000}
+
+\SetZUGFeRDData{
+	id=1337,
+	unit=hour,
+	seller/name=komavar,
+	seller/email=komavar,
+	seller/contact-name=komavar,
+	seller/contact-phone=komavar,
+	seller/contact-email=komavar,
+	seller/id={1123},
+	seller/postcode = {20253},
+	seller/city ={Hamburg},
+	seller/country = DE,
+	seller/address = {Address 1},
+	seller/taxid = {DE123456789},
+	buyer/reference = {buyer-reference},
+	buyer/name = {Buyer Name},
+	buyer/postcode = {20253},
+	buyer/city ={Hamburg},
+	buyer/country = DE,
+	buyer/email = {invoice@example.org},
+	due-date={20240118},
+	payment-means / type = 1,
+	tax/add-exemption-reason-auto={E={Kein Ausweis von Umsatzsteuer, da Kleinunternehmer*in gemaess Paragraph 19 UStG}}% avoid umlauts for testing as \SHOWFILE is annoying...
+}
+
+\begin{document}
+\ExplSyntaxOn
+	\begin{ZUGFeRD}
+	\zugferd_write_Item:nnnnnnn {tax/rate=0, tax/category=E} {loewe-1} {0} {Plushie ~ \TeX\ lion} {31.89} {2} {63.78}%special required for space in expl3-mode
+	\zugferd_startInvoiceSums:
+	\group_begin:
+	\zugferd_write_TaxEntry:nnnn {E} {0} {63.78} {0}
+	\group_end:
+	\zugferd_write_Summation:nnnnnnnn
+		{63.78}% LineTotalAmount
+		{0} %ChargeTotalAmount
+		{0} %AllowanceTotalAmount
+		{63.78} %TaxBasisTotalAmount
+		{0} %TaxTotalAmount
+		{63.78} %GrandTotalAmount
+		{0} % TotalPrepaidAmount
+		{63.78} %DuePayableAmount = GrandTotalAmount - TotalPrepaidAmount
+	\zugferd_stopInvoiceSums:
+	\end{ZUGFeRD}
+
+	test
+\endlinechar=10
+\char_set_catcode:nn {10}{12}%
+\START%
+\SHOWFILE{\jobname _zugferd.xml}%
+\END%
+\ExplSyntaxOff%
+\end{document}%

--- a/testfiles/seller-komavar.tlg
+++ b/testfiles/seller-komavar.tlg
@@ -1,14 +1,14 @@
 This is a generated file for the l3build validation system.
 Don't change this file in any respect.
--------- zugferd-basic_zugferd.xml (start) ---------
-(zugferd-basic_zugferd.xml) <?xml version='1.0' encoding='UTF-8' ?>
+-------- seller-komavar_zugferd.xml (start) ---------
+(seller-komavar_zugferd.xml) <?xml version='1.0' encoding='UTF-8' ?>
 <rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
   <rsm:ExchangedDocumentContext>
     <ram:BusinessProcessSpecifiedDocumentContextParameter>
       <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
     </ram:BusinessProcessSpecifiedDocumentContextParameter>
     <ram:GuidelineSpecifiedDocumentContextParameter>
-      <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:factur-x.eu:1p0:basic</ram:ID>
+      <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0</ram:ID>
     </ram:GuidelineSpecifiedDocumentContextParameter>
   </rsm:ExchangedDocumentContext>
   <rsm:ExchangedDocument>
@@ -21,9 +21,10 @@ Don't change this file in any respect.
   <rsm:SupplyChainTradeTransaction>
     <ram:IncludedSupplyChainTradeLineItem>
       <ram:AssociatedDocumentLineDocument>
-        <ram:LineID>1</ram:LineID>
+        <ram:LineID>loewe-1</ram:LineID>
       </ram:AssociatedDocumentLineDocument>
       <ram:SpecifiedTradeProduct>
+        <ram:SellerAssignedID>0</ram:SellerAssignedID>
         <ram:Name>Plushie TeX lion</ram:Name>
       </ram:SpecifiedTradeProduct>
       <ram:SpecifiedLineTradeAgreement>
@@ -37,8 +38,8 @@ Don't change this file in any respect.
       <ram:SpecifiedLineTradeSettlement>
         <ram:ApplicableTradeTax>
           <ram:TypeCode>VAT</ram:TypeCode>
-          <ram:CategoryCode>S</ram:CategoryCode>
-          <ram:RateApplicablePercent>19</ram:RateApplicablePercent>
+          <ram:CategoryCode>E</ram:CategoryCode>
+          <ram:RateApplicablePercent>0</ram:RateApplicablePercent>
         </ram:ApplicableTradeTax>
         <ram:SpecifiedTradeSettlementLineMonetarySummation>
           <ram:LineTotalAmount>63.78</ram:LineTotalAmount>
@@ -46,20 +47,42 @@ Don't change this file in any respect.
       </ram:SpecifiedLineTradeSettlement>
     </ram:IncludedSupplyChainTradeLineItem>
     <ram:ApplicableHeaderTradeAgreement>
+      <ram:BuyerReference>buyer-reference</ram:BuyerReference>
       <ram:SellerTradeParty>
+        <ram:ID>1123</ram:ID>
         <ram:Name>peiTeX (Marei Peischl)</ram:Name>
+        <ram:DefinedTradeContact>
+          <ram:PersonName>peiTeX (Marei Peischl)</ram:PersonName>
+          <ram:TelephoneUniversalCommunication>
+            <ram:CompleteNumber>+4900000000</ram:CompleteNumber>
+          </ram:TelephoneUniversalCommunication>
+          <ram:EmailURIUniversalCommunication>
+            <ram:URIID>kontakt@peitex.de</ram:URIID>
+          </ram:EmailURIUniversalCommunication>
+        </ram:DefinedTradeContact>
         <ram:PostalTradeAddress>
+          <ram:PostcodeCode>20253</ram:PostcodeCode>
+          <ram:LineOne>Address 1</ram:LineOne>
+          <ram:CityName>Hamburg</ram:CityName>
           <ram:CountryID>DE</ram:CountryID>
         </ram:PostalTradeAddress>
+        <ram:URIUniversalCommunication>
+          <ram:URIID schemeID="EM">kontakt@peitex.de</ram:URIID>
+        </ram:URIUniversalCommunication>
         <ram:SpecifiedTaxRegistration>
-          <ram:ID schemeID="VA">DE123456789</ram:ID>
+          <ram:ID schemeID="FC">DE123456789</ram:ID>
         </ram:SpecifiedTaxRegistration>
       </ram:SellerTradeParty>
       <ram:BuyerTradeParty>
         <ram:Name>Buyer Name</ram:Name>
         <ram:PostalTradeAddress>
+          <ram:PostcodeCode>20253</ram:PostcodeCode>
+          <ram:CityName>Hamburg</ram:CityName>
           <ram:CountryID>DE</ram:CountryID>
         </ram:PostalTradeAddress>
+        <ram:URIUniversalCommunication>
+          <ram:URIID schemeID="EM">invoice@example.org</ram:URIID>
+        </ram:URIUniversalCommunication>
       </ram:BuyerTradeParty>
     </ram:ApplicableHeaderTradeAgreement>
     <ram:ApplicableHeaderTradeDelivery>
@@ -71,12 +94,17 @@ Don't change this file in any respect.
     </ram:ApplicableHeaderTradeDelivery>
     <ram:ApplicableHeaderTradeSettlement>
       <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+      <ram:SpecifiedTradeSettlementPaymentMeans>
+        <ram:TypeCode>1</ram:TypeCode>
+        <ram:Information>Instrument not defined</ram:Information>
+      </ram:SpecifiedTradeSettlementPaymentMeans>
       <ram:ApplicableTradeTax>
-        <ram:CalculatedAmount>12.12</ram:CalculatedAmount>
+        <ram:CalculatedAmount>0.00</ram:CalculatedAmount>
         <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:ExemptionReason>Kein Ausweis von Umsatzsteuer, da Kleinunternehmer*in gemaess Paragraph 19 UStG</ram:ExemptionReason>
         <ram:BasisAmount>63.78</ram:BasisAmount>
-        <ram:CategoryCode>S</ram:CategoryCode>
-        <ram:RateApplicablePercent>19</ram:RateApplicablePercent>
+        <ram:CategoryCode>E</ram:CategoryCode>
+        <ram:RateApplicablePercent>0</ram:RateApplicablePercent>
       </ram:ApplicableTradeTax>
       <ram:SpecifiedTradePaymentTerms>
         <ram:DueDateDateTime>
@@ -88,14 +116,14 @@ Don't change this file in any respect.
         <ram:ChargeTotalAmount>0.00</ram:ChargeTotalAmount>
         <ram:AllowanceTotalAmount>0.00</ram:AllowanceTotalAmount>
         <ram:TaxBasisTotalAmount>63.78</ram:TaxBasisTotalAmount>
-        <ram:TaxTotalAmount currencyID="EUR">12.12</ram:TaxTotalAmount>
-        <ram:GrandTotalAmount>75.90</ram:GrandTotalAmount>
+        <ram:TaxTotalAmount currencyID="EUR">0.00</ram:TaxTotalAmount>
+        <ram:GrandTotalAmount>63.78</ram:GrandTotalAmount>
         <ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>
-        <ram:DuePayableAmount>75.90</ram:DuePayableAmount>
+        <ram:DuePayableAmount>63.78</ram:DuePayableAmount>
       </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
     </ram:ApplicableHeaderTradeSettlement>
   </rsm:SupplyChainTradeTransaction>
 </rsm:CrossIndustryInvoice>
--------- zugferd-basic_zugferd.xml (end) -----------
+-------- seller-komavar_zugferd.xml (end) -----------
 ***************
 Compilation 1 of test file completed with exit status 0

--- a/zugferd.dtx
+++ b/zugferd.dtx
@@ -1723,7 +1723,7 @@
 % \begin{implementation}
 %    \begin{macrocode}
 	id .choice:,
-	id / komavar .code:n = \tl_gset:Nf \g_@@_id_tl {\scr@invoice@var},
+	id / komavar .code:n = \tl_gset:Nn \g_@@_id_tl {\scr@invoice@var},
 	id / unknown .code:n = \tl_gset:Nn \g_@@_id_tl {#1},
 %    \end{macrocode}
 % \end{implementation}
@@ -1921,11 +1921,11 @@
 %    \begin{macrocode}
 	subject .choice:,
 	subject / komavar .code:n = {
-		\tl_gset:Nf \g_@@_subject_tl {\scr@subject@var}
+		\tl_gset:Nn \g_@@_subject_tl {\scr@subject@var}
 	},
 	subject / unknown .code:n = \tl_gset:Nn \g_@@_subject_tl {#1},
 	fromaddress .choice:,
-	fromaddress / komavar .code:n = \tl_gset:Nf \g_@@_fromaddress_tl
+	fromaddress / komavar .code:n = \tl_gset:Nn \g_@@_fromaddress_tl
 		{\scr@fromaddress@var},
 	fromaddress / unknown .code:n = \tl_gset:Nn \g_@@_fromaddress_tl {#1},
 	add-note .code:n = \seq_gput_right:Nn \g_@@_notes_seq {#1},
@@ -2109,6 +2109,73 @@
 	}
 }
 %    \end{macrocode}
+% \end{implementation}
+% \begin{documentation}
+% \subsubsection{Seller fields with KOMA-Script variable support}
+% \changes{v0.11}{2026-04-10}{Add komavar support for seller name, email and contact fields}
+% In addition to the generic party options, the \option{seller} party supports the value \value{komavar}
+% for the fields \option{name}, \option{email}, \option{contact-name}, \option{contact-email} and \option{contact-phone}.
+% This allows reading the corresponding data directly from KOMA-Script letter variables, avoiding
+% duplicate data entry when a letter option file already provides this information.
+%
+% \begin{examplecode}
+% \setkomavar{fromname}{Marei Peischl}
+% \setkomavar{fromemail}{kontakt@peitex.de}
+% \setkomavar{fromphone}{+4900000000}
+%
+% \SetZUGFeRDData{
+%   seller/name = komavar,
+%   seller/email = komavar,
+%   seller/contact-name = komavar,
+%   seller/contact-email = komavar,
+%   seller/contact-phone = komavar,
+% }
+% \end{examplecode}
+%
+% \noindent The KOMA-Script variables are read lazily at XML-write time, so the order of
+% \cs{setkomavar} and \cs{SetZUGFeRDData} does not matter.
+% The same lazy evaluation applies to \option{id}, \option{subject}, \option{fromaddress}
+% and \option{buyer/reference} when using \value{komavar}.
+%
+% \begin{tabular}{ll}
+% \textbf{Option} & \textbf{KOMA-Script variable} \\
+% \option{seller/name} & |fromname| \\
+% \option{seller/email} & |fromemail| \\
+% \option{seller/contact-name} & |fromname| \\
+% \option{seller/contact-email} & |fromemail| \\
+% \option{seller/contact-phone} & |fromphone| \\
+% \end{tabular}
+% \end{documentation}
+% \begin{implementation}
+%    \begin{macrocode}
+\keys_define:nn {zugferd/seller} {
+	name .choice:,
+	name / komavar .code:n =
+		\prop_gput:Nnn \g_@@_seller_AddressData_prop {name} {\scr@fromname@var},
+	name / unknown .code:n =
+		\prop_gput:Nne \g_@@_seller_AddressData_prop {name} {\tl_trim_spaces:n {#1}},
+	email .choice:,
+	email / komavar .code:n =
+		\prop_gput:Nnn \g_@@_seller_AddressData_prop {email} {\scr@fromemail@var},
+	email / unknown .code:n =
+		\prop_gput:Nne \g_@@_seller_AddressData_prop {email} {\tl_trim_spaces:n {#1}},
+	contact-name .choice:,
+	contact-name / komavar .code:n =
+		\prop_gput:Nnn \g_@@_seller_AddressData_prop {contact-name} {\scr@fromname@var},
+	contact-name / unknown .code:n =
+		\prop_gput:Nne \g_@@_seller_AddressData_prop {contact-name} {\tl_trim_spaces:n {#1}},
+	contact-email .choice:,
+	contact-email / komavar .code:n =
+		\prop_gput:Nnn \g_@@_seller_AddressData_prop {contact-email} {\scr@fromemail@var},
+	contact-email / unknown .code:n =
+		\prop_gput:Nne \g_@@_seller_AddressData_prop {contact-email} {\tl_trim_spaces:n {#1}},
+	contact-phone .choice:,
+	contact-phone / komavar .code:n =
+		\prop_gput:Nnn \g_@@_seller_AddressData_prop {contact-phone} {\scr@fromphone@var},
+	contact-phone / unknown .code:n =
+		\prop_gput:Nne \g_@@_seller_AddressData_prop {contact-phone} {\tl_trim_spaces:n {#1}},
+}
+%    \end{macrocode}
 % \begin{macro}{\_@@_TradePartyIdentity:N \_@@_PostalTradeAddress:N,\_@@_DefinedTradeContact:N}
 % Wrappers to map the property list items to the writing macro.
 % \changes{v0.9c}{2024-12-08}{Add TradePartyName to support additional legal information.}
@@ -2265,10 +2332,7 @@
 \_@@_define_xml_writer:Nn \_@@_ApplicableHeaderTradeAgreement: {
 	\_@@_write_xml:n {<ram:ApplicableHeaderTradeAgreement>}
 	\int_gincr:N \g_@@_indent_int
-	\bool_lazy_and:nnF
-		{\tl_if_blank_p:V \g_@@_buyer_reference_tl}
-		{\g_@@_minimum_bool}
-	{
+	\tl_if_blank:VF \g_@@_buyer_reference_tl {
 		\_@@_write_xml:e {
 			<ram:BuyerReference>\g_@@_buyer_reference_tl</ram:BuyerReference>
 		}
@@ -2364,7 +2428,7 @@
 \keys_define:nn {zugferd/buyer} {
 	reference .choice:,
 	reference / komavar .code:n = {
-		\tl_gset:Nf \g_@@_buyer_reference_tl {\scr@yourref@var}
+		\tl_gset:Nn \g_@@_buyer_reference_tl {\scr@yourref@var}
 	},
 	reference / unknown .code:n = {
 		\tl_gset:Nn \g_@@_buyer_reference_tl {#1}


### PR DESCRIPTION
## Problem

   Two bugs and one missing feature were identified during real-world XRechnung 3.0 invoice generation:

   ### Bug 1 — komavar keys evaluated too early

   `id=komavar`, `subject=komavar`, `fromaddress=komavar` and `buyer/reference=komavar` all used `\tl_gset:Nf`, which expands the KOMA-Script variable **immediately** at `\SetZUGFeRDData` call time. If `\setkomavar` is called afterwards (a natural ordering when using a letter option file), the captured value is empty — causing BR-02 (empty invoice number) and PEPPOL-EN16931-R008 (empty elements) validation errors.

   ### Bug 2 — empty `<ram:BuyerReference/>` written unconditionally

   The `\bool_lazy_and:nnF` condition for `BuyerReference` wrote an empty element whenever the reference was blank **and** the format was not `minimum` (e.g. xrechnung). This produced invalid XML (PEPPOL-EN16931-R008).

   ### Missing feature — seller data duplicated between letter option file and `\SetZUGFeRDData`

   Users who already define sender data via `\setkomavar{fromname}` etc. in a letter option file had to repeat the same information in `\SetZUGFeRDData{seller/name=..., seller/email=..., ...}`. There was no way to reference KOMA-Script variables for seller fields.

   ## Changes

   ### Fixes

   - **`\tl_gset:Nf` → `\tl_gset:Nn`** for `id/komavar`, `subject/komavar`, `fromaddress/komavar` and `buyer/reference/komavar` (zugferd.dtx, lines 1726, 1924, 1928, 2367). The KOMA-Script variable token is now stored as-is and resolved lazily at XML-write time via e-expansion — the order of `\setkomavar` and `\SetZUGFeRDData` no longer matters.

   - **`\bool_lazy_and:nnF` → `\tl_if_blank:VF`** for BuyerReference (zugferd.dtx, lines 2268–2275). The element is now only written when a non-blank value is present.

   ### Feature — `seller/name=komavar` and friends

   New `komavar` choice for five seller-specific fields, mapping to standard KOMA-Script letter variables:

   | Option | KOMA-Script variable |
   |---|---|
   | `seller/name` | `fromname` |
   | `seller/email` | `fromemail` |
   | `seller/contact-name` | `fromname` |
   | `seller/contact-email` | `fromemail` |
   | `seller/contact-phone` | `fromphone` |

   Values are stored with `\prop_gput:Nnn` (no expansion) and resolved lazily at XML-write time, consistent with the timing fix above.

   **Example** — with a letter option file that already calls `\setkomavar{fromname}{...}`, the seller block can now be written without duplication:

   ```latex
   \SetZUGFeRDData{
     id          = komavar,           % \scr@invoice@var
     seller/name = komavar,           % \scr@fromname@var
     seller/email = komavar,          % \scr@fromemail@var
     seller/contact-name  = komavar,  % \scr@fromname@var
     seller/contact-email = komavar,  % \scr@fromemail@var
     seller/contact-phone = komavar,  % \scr@fromphone@var
     ...
   }
   ```

   ### Supporting changes

   - `DEMO-rechnung-zugferd-Kleinunternehmen.tex` updated to demonstrate `seller/name=komavar` and similar, and `seller/id` uncommented (required for BR-CO-26 when no VAT ID is present).
   - `testfiles/seller-komavar` added to cover the new feature.
   - `testfiles/zugferd-basic.tlg` updated to reflect the corrected (empty-element-free) BuyerReference behaviour.
   - `docker-compose.yml` added for local test runs without a local TeX Live installation (`docker compose run --rm l3build`).
   - CI workflow extended with `l3build unpack` and a `zugferd-sty` artifact so the extracted `zugferd.sty` is available for download directly from the CI run.

🤖 Generated with support from [Claude Code](https://claude.com/claude-code)